### PR TITLE
rules_python_external upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ is used to for third-party `pip` packaging.
 ##### Dependency Management
 
 > ⚠️ **Note:** [`rules_python`](https://github.com/bazelbuild/rules_python) is currently designated as "ALPHA" software. The UX of managing third-party dependencies is pretty bad.
-> For managing third-party dependencies, I'd recommend you try https://github.com/dillon-giacoppo/rules_python_external.
+> For managing third-party dependencies this project uses https://github.com/dillon-giacoppo/rules_python_external, which I'd recommend you try.
 
 In order to add new third-party packages for Python, add them to [`tools/dependencies/python_requirements.txt`](/tools/dependencies/python_requirements.txt).
+
+##### Gradual Type-Checking (MyPy)
+
+[thundergolfer/bazel-mypy-integration](https://github.com/thundergolfer/bazel-mypy-integration) is used to check any type annotations at `bazel build` time.
 
 ## Development
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -82,19 +82,25 @@ http_archive(
     url = "https://github.com/uri-canva/rules_python/archive/{}.tar.gz".format(rules_python_version),
 )
 
-load("@io_bazel_rules_python//python:pip.bzl", "pip_import", "pip_repositories")
+# Third-Party packaging support
+rules_python_external_version = "12bfbdffc57bbaf9a3de31e6a7acdc415eb9de72"
 
-pip_repositories()
-
-pip_import(
-    name = "pip_dependencies",
-    requirements = "//tools/dependencies:python_requirements.txt",
+http_archive(
+    name = "rules_python_external",
+    sha256 = "", # Fill in with correct sha256 of your COMMIT_SHA version
+    strip_prefix = "rules_python_external-{version}".format(version = rules_python_external_version),
+    url = "https://github.com/dillon-giacoppo/rules_python_external/archive/{version}.zip".format(version = rules_python_external_version),
 )
 
-# Load the pip_install symbol for my_deps, and create the dependencies repositories.
-load("@pip_dependencies//:requirements.bzl", "pip_install")
+# Install the rule dependencies
+load("@rules_python_external//:repositories.bzl", "rules_python_external_dependencies")
+rules_python_external_dependencies()
 
-pip_install()
+load("@rules_python_external//:defs.bzl", "pip_install")
+pip_install(
+    name = "py_deps",
+    requirements = "//tools/dependencies:python_requirements.txt",
+)
 
 # MYPY SUPPORT
 mypy_integration_version = "0.0.4"

--- a/book_sorting/BUILD
+++ b/book_sorting/BUILD
@@ -1,4 +1,4 @@
-load("@pip_dependencies//:requirements.bzl", "requirement")
+load("@py_deps//:requirements.bzl", "requirement")
 
 MAIN_SRCS = glob(["*.py"])
 


### PR DESCRIPTION
Moving to usage of https://github.com/dillon-giacoppo/rules_python_external as I work on the project myself and it's used internally at Canva now. 