### PR TITLE
Register Buildbuddy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,3 +30,7 @@ build --incompatible_depset_union=false
 # Note that this uses a different sandboxing mechanism than the action spawn:
 # https://github.com/bazelbuild/bazel/issues/6111
 build --worker_sandboxing
+
+# BuildBuddy - https://buildbuddy.io/
+build --bes_results_url=https://app.buildbuddy.io/invocation/
+build --bes_backend=grpc://events.buildbuddy.io:1985

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ In order to add new third-party packages for Python, add them to [`tools/depende
 This repository's CI is managed by [Buildkite](https://buildkite.com), the CI platform used by Pinterest and Canva to manage Bazel monorepos,
 as well as being [used by the Bazel open-source project itself](https://buildkite.com/bazel).
 
+### Build Observability + Analysis
+
+This project is using [Buildbuddy.IO](https://buildbuddy.io/). Every build run locally or in CI get its own `https://app.buildbuddy.io/invocation/xyz123...` URL which analyses and records the build's information.
+
 ### Linting
 
 [`./tools/linting/lint.sh`](tools/linting/lint.sh) will lint all source-code in the repo _and_ all Bazel files.


### PR DESCRIPTION
### Description 

⚠️ Currently getting a blank white screen when hitting a build invocation page, eg. https://app.buildbuddy.io/invocation/93a9d34a-3dce-47f5-9770-59799ad9e65f

```
TypeError: Cannot read property 'buildEvent' of undefined
```

---

**Update:** The error appears to have gone now. I can see the BuildBuddy page

![image](https://user-images.githubusercontent.com/12058921/76714653-6ff2a500-677c-11ea-92ea-14be08b94909.png)
