### PR TITLE
Support ignoring certain languages

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,7 +151,7 @@ mypy_integration_pip_deps()
 ######################
 # RUBY SUPPORT
 ######################
-rules_ruby_version = "a0d21e570f79424e6125df6c691ab27ed7454e1a"
+#rules_ruby_version = "a0d21e570f79424e6125df6c691ab27ed7454e1a"
 
 # TODO(Jonathon): Reinstate this when it isn't breaking CI
 # Ref: https://buildkite.com/thundergolfer-inc/the-one-true-bazel-monorepo/builds/162#7a972413-1ff2-43a9-8385-a1a871acf358
@@ -240,7 +240,7 @@ build_external_workspace(name = "3rdparty_jvm")
 scala_deps()
 
 #######################################
-# TYPESCRIPT / NODE-JS
+# TYPESCRIPT / NODE-JS SUPPORT
 #######################################
 
 rules_nodejs_version = "1.0.1"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -240,7 +240,7 @@ build_external_workspace(name = "3rdparty_jvm")
 scala_deps()
 
 #######################################
-# TYPESCRIPT / NODE-JS SUPPORT
+# TYPESCRIPT / NODEJS SUPPORT
 #######################################
 
 rules_nodejs_version = "1.0.1"
@@ -275,7 +275,7 @@ load("@npm_bazel_typescript//:index.bzl", "ts_setup_workspace")
 ts_setup_workspace()
 
 ######################
-# *OTHER*
+# OTHER
 ######################
 
 # requirement of 'com_github_bazelbuild_buildtools'

--- a/tools/reduce_supported_languages.py
+++ b/tools/reduce_supported_languages.py
@@ -43,6 +43,7 @@ BAZELIGNORE_LINES = {
 
 def display_instructions(bazel_workspace_file, target_lang, p):
     print(f"{BColors.OKGREEN}1. Add the following lines to {pathlib.Path(REPO_ROOT, '.bazelignore')}{BColors.ENDC}")
+    print(f"{BColors.OKGREEN}   Alternatively, remove the folders.{BColors.ENDC}")
     print(BColors.OKGREEN + ("-" * 50) + BColors.ENDC)
     print("\n".join(BAZELIGNORE_LINES[target_lang]))
     print()
@@ -67,7 +68,6 @@ def main(target_lang):
     pttrn = re.compile(r"#{10,50}\n# [\w\/\s]+\n#{10,50}")
     parts = pttrn.split(workspace_contents)
 
-    # clean parts
     for p in parts:
         if target_lang in p:
             display_instructions(

--- a/tools/reduce_supported_languages.py
+++ b/tools/reduce_supported_languages.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+This script is used to adapt the Bazel workspace so that certain languages
+are no longer built. This can be used when wanting to avoid difficult setup of prerequisites
+or if you just don't care about a particular language and want to remove support.
+"""
+import argparse
+import pathlib
+import subprocess
+import re
+
+
+class BColors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+REPO_ROOT = subprocess.run(
+    "git rev-parse --show-toplevel",
+    shell=True,
+    check=True,
+    capture_output=True,
+).stdout.decode().strip()
+
+REMOVEABLE_LANGUAGES = {"ruby", "rust", "typescript"}
+BAZELIGNORE_LINES = {
+    "ruby": [
+        "ruby/"
+    ],
+    "rust": [
+        "rust/"
+    ],
+    "typescript": [
+        "frontend/"
+    ]
+}
+
+def display_instructions(bazel_workspace_file, target_lang, p):
+    print(f"{BColors.OKGREEN}1. Add the following lines to {pathlib.Path(REPO_ROOT, '.bazelignore')}{BColors.ENDC}")
+    print(BColors.OKGREEN + ("-" * 50) + BColors.ENDC)
+    print("\n".join(BAZELIGNORE_LINES[target_lang]))
+    print()
+    print(f"{BColors.OKGREEN}2. Comment-out or remove the following part of the {bazel_workspace_file}{BColors.ENDC}")
+    print(BColors.OKGREEN + ("-" * 50) + BColors.ENDC)
+    print(p)
+    exit(0)
+
+
+def main(target_lang):
+    if target_lang not in REMOVEABLE_LANGUAGES:
+        print(
+            f"This script supports removing the following languages from the WORKSPACE: {REMOVEABLE_LANGUAGES}\n"
+            f"Language '{target_lang}' is not removeable."
+        )
+        exit(1)
+
+    bazel_workspace_file = pathlib.Path(REPO_ROOT, "WORKSPACE")
+    with open(bazel_workspace_file, "r") as f:
+        workspace_contents = f.read()
+
+    pttrn = re.compile(r"#{10,50}\n# [\w\/\s]+\n#{10,50}")
+    parts = pttrn.split(workspace_contents)
+
+    # clean parts
+    for p in parts:
+        if target_lang in p:
+            display_instructions(
+                bazel_workspace_file,
+                target_lang,
+                p
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='XXXX.')
+    parser.add_argument(
+        "target_language",
+        help="YYYY"
+    )
+    args = parser.parse_args()
+    main(args.target_language)


### PR DESCRIPTION
### Description 

For some people coming to this repo, setting up the prerequisites of a particular language may be too difficult or they may not care about that language and want to ignore. The `.bazelignore` can ignore targets easily, however due to how Bazel works the `WORKSPACE` will still attempt to setup stuff and that would break. 

This script is here to provide straightforward instructions for how to remove a particular language from this monorepo. 