### PR TITLE
python interpeter macro

### DIFF
--- a/scraping/nyt_bestsellers/BUILD
+++ b/scraping/nyt_bestsellers/BUILD
@@ -1,16 +1,14 @@
 load("@py_deps//:requirements.bzl", "requirement")
 load("//tools/python/interpreter:macro.bzl", "py_interpreter")
 
-DEPS = [
-    requirement("requests"),
-    requirement("beautifulsoup4"),
-]
-
 py_binary(
     name = "nyt_bestsellers",
     srcs = ["main.py"],
     main = "main.py",
-    deps = DEPS,
+    deps = [
+        requirement("requests"),
+        requirement("beautifulsoup4"),
+    ],
 )
 
 # Try it with:

--- a/scraping/nyt_bestsellers/BUILD
+++ b/scraping/nyt_bestsellers/BUILD
@@ -1,11 +1,23 @@
 load("@py_deps//:requirements.bzl", "requirement")
+load("//tools/python/interpreter:macro.bzl", "py_interpreter")
+
+DEPS = [
+    requirement("requests"),
+    requirement("beautifulsoup4"),
+]
 
 py_binary(
     name = "nyt_bestsellers",
     srcs = ["main.py"],
     main = "main.py",
-    deps = [
-        requirement("requests"),
-        requirement("beautifulsoup4"),
-    ],
+    deps = DEPS,
+)
+
+# Try it with:
+# $ bazel run //scraping/nyt_bestsellers:repl
+# >>> from scraping.nyt_bestsellers.main import run
+# >>> run()
+py_interpreter(
+    name = "repl",
+    deps = [":nyt_bestsellers"],
 )

--- a/tools/python/interpreter/BUILD
+++ b/tools/python/interpreter/BUILD
@@ -1,0 +1,12 @@
+load("@rules_python//python:python.bzl", "py_binary")
+load("@py_deps//:requirements.bzl", "all_requirements")
+
+# A Python interpreter (or REPL) with the monorepo's Python dependencies all available.
+py_binary(
+    name = "interpreter",
+    srcs = ["interpreter.py"],
+    visibility = ["//visibility:public"],
+    deps = all_requirements,
+)
+
+exports_files(["interpreter.py"])

--- a/tools/python/interpreter/interpreter.py
+++ b/tools/python/interpreter/interpreter.py
@@ -1,0 +1,3 @@
+import code
+
+code.interact(local=locals())

--- a/tools/python/interpreter/interpreter.py
+++ b/tools/python/interpreter/interpreter.py
@@ -1,6 +1,4 @@
 import code
 
 # https://docs.python.org/3/library/code.html
-code.interact(
-    local=locals()
-)
+code.interact(local=locals())

--- a/tools/python/interpreter/interpreter.py
+++ b/tools/python/interpreter/interpreter.py
@@ -1,3 +1,6 @@
 import code
 
-code.interact(local=locals())
+# https://docs.python.org/3/library/code.html
+code.interact(
+    local=locals()
+)

--- a/tools/python/interpreter/macro.bzl
+++ b/tools/python/interpreter/macro.bzl
@@ -1,0 +1,9 @@
+def py_interpreter(name, deps, visibility = None):
+    native.py_binary(
+        name = name,
+        srcs = ["//tools/python/interpreter:interpreter.py"],
+        main = "//tools/python/interpreter:interpreter.py",
+        deps = [
+            "//tools/python/interpreter",
+        ] + deps,
+    )


### PR DESCRIPTION
### Description 

Provides a macro that allows a user to get a Python REPL that has access to all the external Py dependencies in the repo _plus_ any internal packages they specify.