### PR TITLE
Update bazel-gazelle and rules_go to latest releases

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,13 +7,13 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # GOLANG SUPPORT
 ######################
 
-rules_go_version = "v0.22.6"
+rules_go_version = "v0.24.9"
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "e0d2e3d92ef8b3704f26ac19231ef9aba66c8a3bdec4aca91a22ad7d6e6f3ef7",
+    sha256 = "81eff5df9077783b18e93d0c7ff990d8ad7a3b8b3ca5b785e1c483aacdb342d7",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/{version}/rules_go-{version}.tar.gz".format(version = rules_go_version),
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/{version}/rules_go-{version}.tar.gz".format(version = rules_go_version),
         "https://github.com/bazelbuild/rules_go/releases/download/{version}/rules_go-{version}.tar.gz".format(version = rules_go_version),
     ],
 )
@@ -24,12 +24,12 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-gazelle_version = "v0.21.1"
+gazelle_version = "v0.22.2"
 
 # Gazelle - used for Golang external dependencies
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
+    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/{version}/bazel-gazelle-{version}.tar.gz".format(version = gazelle_version),
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/{version}/bazel-gazelle-{version}.tar.gz".format(version = gazelle_version),

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 # GOLANG SUPPORT
 ######################
 
-rules_go_version = "v0.24.9"
+rules_go_version = "v0.24.9"  # latest @ 2020/12/12
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -24,7 +24,7 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-gazelle_version = "v0.22.2"
+gazelle_version = "v0.22.2"  # latest @ 2020/12/12
 
 # Gazelle - used for Golang external dependencies
 http_archive(


### PR DESCRIPTION
* `rules_go` releases page: https://github.com/bazelbuild/rules_go/releases
* `bazel-gazelle` releases page: https://github.com/bazelbuild/bazel-gazelle/releases